### PR TITLE
Fixes #242

### DIFF
--- a/src/lib/interfaces-grpc-1.0.ts
+++ b/src/lib/interfaces-grpc-1.0.ts
@@ -308,3 +308,7 @@ export interface GetProcessResponse {
 	readonly resourceName: string
 	readonly bpmnXml: string
 }
+
+export interface ResolveIncidentRequest {
+	readonly incidentKey: string
+}

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -87,9 +87,7 @@ export class ZBClient extends TypedEmitter<typeof ConnectionStatusEvent> {
 	private grpc: ZB.ZBGrpc
 	private options: ZBClientOptions
 	private workerCount = 0
-	private workers: Array<
-		ZBWorker<any, any, any> | ZBBatchWorker<any, any, any>
-	> = []
+	private workers: (ZBWorker<any, any, any> | ZBBatchWorker<any, any, any>)[] = []
 	private retry: boolean
 	private maxRetries: number = process.env.ZEEBE_CLIENT_MAX_RETRIES
 		? parseInt(process.env.ZEEBE_CLIENT_MAX_RETRIES, 10)
@@ -809,9 +807,11 @@ export class ZBClient extends TypedEmitter<typeof ConnectionStatusEvent> {
 		)
 	}
 
-	public resolveIncident(incidentKey: string): Promise<void> {
+	public resolveIncident(
+		resolveIncidentRequest: Grpc.ResolveIncidentRequest
+	): Promise<void> {
 		return this.executeOperation('resolveIncident', () =>
-			this.grpc.resolveIncidentSync(incidentKey)
+			this.grpc.resolveIncidentSync(resolveIncidentRequest)
 		)
 	}
 


### PR DESCRIPTION
fix: resolveIncident(incidentKey) is not working

change argument type for resolveIncident method to match the Gateway's API

BREAKING CHANGE: input argument for zbClient.resolveIncident is changed.

 To migrate the code, follow the example below:

    Before:

    zbClient.resolveIncident(incidentKey);

    After:

    zbClient.resolveIncident({incidentKey: incidentKey});

Fixes #242 
