### PR TITLE
bump got to 11.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "zeebe-node",
-	"version": "8.0.3",
+	"version": "0.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zeebe-node",
-			"version": "8.0.3",
+			"version": "0.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.7.0",
@@ -17,7 +17,7 @@
 				"debug": "^4.2.0",
 				"fast-xml-parser": "^3.12.12",
 				"fp-ts": "^2.5.1",
-				"got": "^9.6.0",
+				"got": "^11.8.5",
 				"long": "^4.0.0",
 				"promise-retry": "^1.1.1",
 				"stack-trace": "0.0.10",
@@ -2076,11 +2076,14 @@
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
 			}
 		},
 		"node_modules/@sinonjs/commons": {
@@ -2124,14 +2127,14 @@
 			"dev": true
 		},
 		"node_modules/@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
 			"dependencies": {
-				"defer-to-connect": "^1.0.1"
+				"defer-to-connect": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -2184,6 +2187,17 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "*",
+				"@types/node": "*",
+				"@types/responselike": "*"
+			}
+		},
 		"node_modules/@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -2216,6 +2230,11 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -2241,6 +2260,14 @@
 				"pretty-format": "^27.0.0"
 			}
 		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/long": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -2258,8 +2285,7 @@
 		"node_modules/@types/node": {
 			"version": "10.17.17",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-			"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
-			"dev": true
+			"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
 		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.0",
@@ -2280,6 +2306,14 @@
 			"dev": true,
 			"dependencies": {
 				"@types/retry": "*"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/retry": {
@@ -2860,38 +2894,27 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
 		"node_modules/cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
 				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
+				"keyv": "^4.0.0",
 				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
 			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cacheable-request/node_modules/get-stream": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-			"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cacheable-request/node_modules/lowercase-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"engines": {
 				"node": ">=8"
 			}
@@ -3132,11 +3155,14 @@
 			}
 		},
 		"node_modules/clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
 			"dependencies": {
 				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/co": {
@@ -3519,14 +3545,28 @@
 			"dev": true
 		},
 		"node_modules/decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
 			"dependencies": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "^3.1.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/dedent": {
@@ -3583,18 +3623,6 @@
 				"node": "^8.12.0 || >=9.7.0"
 			}
 		},
-		"node_modules/default-gateway/node_modules/get-stream": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-			"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-			"dev": true,
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/default-gateway/node_modules/p-finally": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -3605,9 +3633,12 @@
 			}
 		},
 		"node_modules/defer-to-connect": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/delay": {
 			"version": "4.3.0",
@@ -3774,11 +3805,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
-		},
-		"node_modules/duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.3.853",
@@ -4420,14 +4446,17 @@
 			}
 		},
 		"node_modules/get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/glob": {
@@ -4515,24 +4544,27 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"version": "11.8.5",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+			"integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
 			"dependencies": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
 		"node_modules/graceful-fs": {
@@ -4629,6 +4661,18 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -8049,9 +8093,9 @@
 			}
 		},
 		"node_modules/json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -8109,11 +8153,11 @@
 			}
 		},
 		"node_modules/keyv": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
+			"integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
 			"dependencies": {
-				"json-buffer": "3.0.0"
+				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/kleur": {
@@ -8692,11 +8736,11 @@
 			}
 		},
 		"node_modules/lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -9015,11 +9059,14 @@
 			}
 		},
 		"node_modules/normalize-url": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -9099,11 +9146,11 @@
 			}
 		},
 		"node_modules/p-cancelable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-each-series": {
@@ -9319,14 +9366,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/prettier": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -9475,6 +9514,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/react-is": {
@@ -9923,6 +9973,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+		},
 		"node_modules/resolve-cwd": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -9971,11 +10026,14 @@
 			}
 		},
 		"node_modules/responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
 			"dependencies": {
-				"lowercase-keys": "^1.0.0"
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/restore-cursor": {
@@ -10598,14 +10656,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -11314,17 +11364,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dependencies": {
-				"prepend-http": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -13349,9 +13388,9 @@
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
 		"@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",
@@ -13396,11 +13435,11 @@
 			}
 		},
 		"@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
 			"requires": {
-				"defer-to-connect": "^1.0.1"
+				"defer-to-connect": "^2.0.0"
 			}
 		},
 		"@tootallnate/once": {
@@ -13450,6 +13489,17 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/cacheable-request": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+			"requires": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "*",
+				"@types/node": "*",
+				"@types/responselike": "*"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -13482,6 +13532,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/http-cache-semantics": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -13507,6 +13562,14 @@
 				"pretty-format": "^27.0.0"
 			}
 		},
+		"@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/long": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -13524,8 +13587,7 @@
 		"@types/node": {
 			"version": "10.17.17",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-			"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
-			"dev": true
+			"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
 		},
 		"@types/parse-json": {
 			"version": "4.0.0",
@@ -13546,6 +13608,14 @@
 			"dev": true,
 			"requires": {
 				"@types/retry": "*"
+			}
+		},
+		"@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"requires": {
+				"@types/node": "*"
 			}
 		},
 		"@types/retry": {
@@ -14009,33 +14079,23 @@
 			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
 			"dev": true
 		},
+		"cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+		},
 		"cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
 				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
+				"keyv": "^4.0.0",
 				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"lowercase-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-				}
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
 			}
 		},
 		"cachedir": {
@@ -14213,9 +14273,9 @@
 			}
 		},
 		"clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -14520,11 +14580,18 @@
 			"dev": true
 		},
 		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "^3.1.0"
+			},
+			"dependencies": {
+				"mimic-response": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+				}
 			}
 		},
 		"dedent": {
@@ -14572,15 +14639,6 @@
 						"strip-final-newline": "^2.0.0"
 					}
 				},
-				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
 				"p-finally": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -14590,9 +14648,9 @@
 			}
 		},
 		"defer-to-connect": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
 		},
 		"delay": {
 			"version": "4.3.0",
@@ -14734,11 +14792,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
-		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"electron-to-chromium": {
 			"version": "1.3.853",
@@ -15236,9 +15289,9 @@
 			"dev": true
 		},
 		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 			"requires": {
 				"pump": "^3.0.0"
 			}
@@ -15307,21 +15360,21 @@
 			"dev": true
 		},
 		"got": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"version": "11.8.5",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+			"integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
 			"requires": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -15395,6 +15448,15 @@
 				"@tootallnate/once": "1",
 				"agent-base": "6",
 				"debug": "4"
+			}
+		},
+		"http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"requires": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
 			}
 		},
 		"https-proxy-agent": {
@@ -18051,9 +18113,9 @@
 			"dev": true
 		},
 		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -18096,11 +18158,11 @@
 			}
 		},
 		"keyv": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
+			"integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
 			"requires": {
-				"json-buffer": "3.0.0"
+				"json-buffer": "3.0.1"
 			}
 		},
 		"kleur": {
@@ -18533,9 +18595,9 @@
 			"dev": true
 		},
 		"lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -18781,9 +18843,9 @@
 			"dev": true
 		},
 		"normalize-url": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm-run-path": {
 			"version": "4.0.1",
@@ -18847,9 +18909,9 @@
 			"dev": true
 		},
 		"p-cancelable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
 		},
 		"p-each-series": {
 			"version": "2.2.0",
@@ -19003,11 +19065,6 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
-		"prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-		},
 		"prettier": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -19124,6 +19181,11 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
 		},
 		"react-is": {
 			"version": "17.0.2",
@@ -19466,6 +19528,11 @@
 				"path-parse": "^1.0.6"
 			}
 		},
+		"resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+		},
 		"resolve-cwd": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -19502,11 +19569,11 @@
 			}
 		},
 		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
 			"requires": {
-				"lowercase-keys": "^1.0.0"
+				"lowercase-keys": "^2.0.0"
 			}
 		},
 		"restore-cursor": {
@@ -20024,11 +20091,6 @@
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
-		"to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
-		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -20504,14 +20566,6 @@
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
-		},
-		"url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"requires": {
-				"prepend-http": "^2.0.0"
-			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"debug": "^4.2.0",
 		"fast-xml-parser": "^3.12.12",
 		"fp-ts": "^2.5.1",
-		"got": "^9.6.0",
+		"got": "^11.8.5",
 		"long": "^4.0.0",
 		"promise-retry": "^1.1.1",
 		"stack-trace": "0.0.10",

--- a/src/lib/OAuthProvider.ts
+++ b/src/lib/OAuthProvider.ts
@@ -1,8 +1,7 @@
 import * as fs from 'fs'
-import * as got from 'got'
+import got from 'got'
 import * as os from 'os'
 const homedir = os.homedir()
-import pkg = require('../../package.json')
 
 const BACKOFF_TOKEN_ENDPOINT_FAILURE = 1000
 
@@ -110,7 +109,7 @@ export class OAuthProvider {
 	}
 
 	private debouncedTokenRequest() {
-		const body = {
+		const json = {
 			audience: this.audience,
 			client_id: this.clientId,
 			client_secret: this.clientSecret,
@@ -119,12 +118,7 @@ export class OAuthProvider {
 
 		return got
 			.post(this.url, {
-				body,
-				form: true,
-				headers: {
-					'content-type': 'application/x-www-form-urlencoded',
-					'user-agent': `zeebe-client-nodejs/${pkg.version}`,
-				},
+				json,
 			})
 			.then(res => {
 				return this.safeJSONParse(res.body).then(token => {


### PR DESCRIPTION
Fixes CVE-2022-33987

## Proposed Changes

  - Bump `got` to `11.8.5` to fix CVE-2022-33987
  - Update the import of `got`
  - Update the usage of `got.post`
