### PR TITLE
fix: pin `@grpc` dependencies to stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "8.1.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grpc/grpc-js": "^1.7.0",
-				"@grpc/proto-loader": "^0.7.2",
+				"@grpc/grpc-js": "1.6.7",
+				"@grpc/proto-loader": "0.6.13",
 				"chalk": "^2.4.2",
 				"console-stamp": "^3.0.2",
 				"dayjs": "^1.8.15",
@@ -885,11 +885,11 @@
 			}
 		},
 		"node_modules/@grpc/grpc-js": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.0.tgz",
-			"integrity": "sha512-wvKxal+40Xx11DXO2q5PfY3UiE25iwTb8SOz6A9IJII/V7d19x2ex0he+GJfVW0JZCaBjCPSjUB0yU9Ecm4WCw==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+			"integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
 			"dependencies": {
-				"@grpc/proto-loader": "^0.7.0",
+				"@grpc/proto-loader": "^0.6.4",
 				"@types/node": ">=12.12.47"
 			},
 			"engines": {
@@ -897,19 +897,19 @@
 			}
 		},
 		"node_modules/@grpc/grpc-js/node_modules/@types/node": {
-			"version": "12.12.62",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-			"integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
 		},
 		"node_modules/@grpc/proto-loader": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.2.tgz",
-			"integrity": "sha512-jCdyLIT/tdQ1zhrbTQnJNK5nbDf0GoBpy5jVNywBzzMDF+Vs6uEaHnfz46dMtDxkvwrF2hzk5Z67goliceH0sA==",
+			"version": "0.6.13",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+			"integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
 			"dependencies": {
 				"@types/long": "^4.0.1",
 				"lodash.camelcase": "^4.3.0",
 				"long": "^4.0.0",
-				"protobufjs": "^7.0.0",
+				"protobufjs": "^6.11.3",
 				"yargs": "^16.2.0"
 			},
 			"bin": {
@@ -9433,9 +9433,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-			"integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -9448,22 +9448,19 @@
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.0",
+				"@types/long": "^4.0.1",
 				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"long": "^4.0.0"
 			},
-			"engines": {
-				"node": ">=12.0.0"
+			"bin": {
+				"pbjs": "bin/pbjs",
+				"pbts": "bin/pbts"
 			}
 		},
 		"node_modules/protobufjs/node_modules/@types/node": {
-			"version": "18.7.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg=="
-		},
-		"node_modules/protobufjs/node_modules/long": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-			"integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
 		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
@@ -12423,30 +12420,30 @@
 			}
 		},
 		"@grpc/grpc-js": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.0.tgz",
-			"integrity": "sha512-wvKxal+40Xx11DXO2q5PfY3UiE25iwTb8SOz6A9IJII/V7d19x2ex0he+GJfVW0JZCaBjCPSjUB0yU9Ecm4WCw==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+			"integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
 			"requires": {
-				"@grpc/proto-loader": "^0.7.0",
+				"@grpc/proto-loader": "^0.6.4",
 				"@types/node": ">=12.12.47"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.12.62",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-					"integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
+					"version": "18.11.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+					"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
 				}
 			}
 		},
 		"@grpc/proto-loader": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.2.tgz",
-			"integrity": "sha512-jCdyLIT/tdQ1zhrbTQnJNK5nbDf0GoBpy5jVNywBzzMDF+Vs6uEaHnfz46dMtDxkvwrF2hzk5Z67goliceH0sA==",
+			"version": "0.6.13",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+			"integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
 			"requires": {
 				"@types/long": "^4.0.1",
 				"lodash.camelcase": "^4.3.0",
 				"long": "^4.0.0",
-				"protobufjs": "^7.0.0",
+				"protobufjs": "^6.11.3",
 				"yargs": "^16.2.0"
 			}
 		},
@@ -19097,9 +19094,9 @@
 			}
 		},
 		"protobufjs": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-			"integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -19111,19 +19108,15 @@
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.0",
+				"@types/long": "^4.0.1",
 				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"long": "^4.0.0"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "18.7.18",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-					"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg=="
-				},
-				"long": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-					"integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+					"version": "18.11.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+					"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"build": "tsc --build src/tsconfig.json",
 		"watch": "tsc --build src/tsconfig.json -w",
 		"watch-docs": "typedoc --watch --tsconfig src/tsconfig.json src/index.ts",
-		"prepare": "husky install",
+		"prepare": "husky install && npm run build",
 		"test": "jest --detectOpenHandles --testPathIgnorePatterns integration local-integration disconnection",
 		"test:integration": "jest --runInBand --testPathIgnorePatterns disconnection --detectOpenHandles --verbose true",
 		"test:local": "jest --runInBand --verbose true --detectOpenHandles local-integration",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
 		]
 	},
 	"dependencies": {
-		"@grpc/grpc-js": "^1.7.0",
-		"@grpc/proto-loader": "^0.7.2",
+		"@grpc/grpc-js": "1.6.7",
+		"@grpc/proto-loader": "0.6.13",
 		"chalk": "^2.4.2",
 		"console-stamp": "^3.0.2",
 		"dayjs": "^1.8.15",


### PR DESCRIPTION
Related to https://github.com/camunda-community-hub/zeebe-client-node-js/issues/288
Related to https://github.com/barmac/zeebe-tls-connection-test/issues/1

Closes https://github.com/camunda-community-hub/zeebe-client-node-js/issues/290