### PR TITLE
Add new Slack inviter URL

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Issue tracker is **ONLY** used for reporting bugs. New features and questions should be discussed on [our slack channel](https://camunda-slack-invite.herokuapp.com/).
+Issue tracker is **ONLY** used for reporting bugs. New features and questions should be discussed on [our slack channel](http://www.camunda.com/slack).
 
 <!--- Provide a general summary of the issue in the Title above -->
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Issue tracker is **ONLY** used for reporting bugs. New features and questions should be discussed on [our slack channel](http://www.camunda.com/slack).
+Issue tracker is **ONLY** used for reporting bugs. New features and questions should be discussed on [our slack channel](https://www.camunda.com/slack).
 
 <!--- Provide a general summary of the issue in the Title above -->
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Issue tracker is **ONLY** used for reporting bugs. New features and questions should be discussed on [our slack channel](https://zeebe-slack-invite.herokuapp.com/).
+Issue tracker is **ONLY** used for reporting bugs. New features and questions should be discussed on [our slack channel](https://camunda-slack-invite.herokuapp.com/).
 
 <!--- Provide a general summary of the issue in the Title above -->
 


### PR DESCRIPTION
Adding new Slack inviter URL as the Zeebe inviter URL is now offline.