### PR TITLE
feat: inherit `customSSL.rootCerts` for oAuth configuration

### DIFF
--- a/src/__tests__/ConfigurationHydrator.spec.ts
+++ b/src/__tests__/ConfigurationHydrator.spec.ts
@@ -360,6 +360,91 @@ test('Uses the explicit region passed in a CamundaCloudConfig', () => {
 	)
 })
 
+describe('Configures secure connection with custom root certs', () => {
+	test('to Camunda Cloud, oAuth inherits <customSSL.rootCerts>', () => {
+		delete process.env.ZEEBE_CAMUNDA_CLOUD_CLUSTER_ID
+		delete process.env.ZEEBE_CLIENT_SECRET
+		delete process.env.ZEEBE_CLIENT_ID
+		delete process.env.ZEEBE_GATEWAY_ADDRESS
+
+		const rootCerts = Buffer.from('CERT', 'utf8')
+
+		// process.env.ZEEBE_GATEWAY_ADDRESS = 'zeebe://localhost:26500'
+		const conf = ConfigurationHydrator.configure('localhost:26600', {
+			camundaCloud: {
+				clientId: 'CLIENT_ID',
+				clientSecret: 'CLIENT_SECRET',
+				clusterId: 'CLUSTER_ID',
+				clusterRegion: 'CLUSTER_REGION',
+			},
+			useTLS: true,
+			customSSL: {
+				rootCerts,
+			},
+		})
+
+		expect(conf.oAuth!.url).toBe(
+			'https://login.cloud.camunda.io/oauth/token'
+		)
+		expect(conf.oAuth!.customRootCert).toBe(rootCerts)
+	})
+
+	test('to Self-managed, oAuth uses <oAuth.customRootCert>', () => {
+		delete process.env.ZEEBE_CAMUNDA_CLOUD_CLUSTER_ID
+		delete process.env.ZEEBE_CLIENT_SECRET
+		delete process.env.ZEEBE_CLIENT_ID
+		delete process.env.ZEEBE_GATEWAY_ADDRESS
+
+		const rootCerts = Buffer.from('CERT', 'utf8')
+		const oAuthRootCerts = Buffer.from('C_CERT', 'utf8')
+
+		// process.env.ZEEBE_GATEWAY_ADDRESS = 'zeebe://localhost:26500'
+		const conf = ConfigurationHydrator.configure('localhost:26600', {
+			oAuth: {
+				audience: 'OAUTH_AUDIENCE',
+				clientId: 'CLIENT_ID',
+				clientSecret: 'CLIENT_SECRET',
+				url: 'OAUTH_URL',
+				customRootCert: oAuthRootCerts,
+			},
+			useTLS: true,
+			customSSL: {
+				rootCerts,
+			},
+		})
+
+		expect(conf.oAuth!.url).toBe('OAUTH_URL')
+		expect(conf.oAuth!.customRootCert).toBe(oAuthRootCerts)
+		expect(conf.customSSL?.rootCerts).toBe(rootCerts)
+	})
+
+	test('to Self-managed, oAuth inherits <customSSL.rootCerts>', () => {
+		delete process.env.ZEEBE_CAMUNDA_CLOUD_CLUSTER_ID
+		delete process.env.ZEEBE_CLIENT_SECRET
+		delete process.env.ZEEBE_CLIENT_ID
+		delete process.env.ZEEBE_GATEWAY_ADDRESS
+
+		const rootCerts = Buffer.from('CERT', 'utf8')
+
+		// process.env.ZEEBE_GATEWAY_ADDRESS = 'zeebe://localhost:26500'
+		const conf = ConfigurationHydrator.configure('localhost:26600', {
+			oAuth: {
+				audience: 'OAUTH_AUDIENCE',
+				clientId: 'CLIENT_ID',
+				clientSecret: 'CLIENT_SECRET',
+				url: 'OAUTH_URL',
+			},
+			useTLS: true,
+			customSSL: {
+				rootCerts,
+			},
+		})
+
+		expect(conf.oAuth!.url).toBe('OAUTH_URL')
+		expect(conf.oAuth!.customRootCert).toBe(rootCerts)
+	})
+})
+
 test('Is insecure by default', () => {
 	delete process.env.ZEEBE_INSECURE_CONNECTION
 	const conf = ConfigurationHydrator.configure('localhost:26600', {})

--- a/src/lib/ConfigurationHydrator.ts
+++ b/src/lib/ConfigurationHydrator.ts
@@ -52,6 +52,18 @@ export class ConfigurationHydrator {
 			...ConfigurationHydrator.getEagerStatus(options),
 			...ConfigurationHydrator.getRetryConfiguration(options),
 		}
+
+		// inherit oAuth custom root certificates, unless
+		// others are explicitly provided
+		if (
+			configuration?.oAuth &&
+			!configuration.oAuth.customRootCert &&
+			configuration.customSSL?.rootCerts
+		) {
+			configuration.oAuth.customRootCert =
+				configuration.customSSL.rootCerts
+		}
+
 		return configuration
 	}
 	public static readonly getLogLevelFromEnv = () =>


### PR DESCRIPTION
Respect custom SSL certificate for C8 SaaS connections, but also simplifies general custom certificate configurations. If we merge this PR then `customSSL.rootCerts` will be inherited by any `oAuth` configuration.

I chose this route over alternatives as I think there is little use-case to configure different root certs, across oAuth and zeebe (GRPC) connections. If needed, then `rootCerts` can be concatenated or custom oAuth root certs can be configured through `oAuth.customRootCert`.

Closes https://github.com/camunda-community-hub/zeebe-client-node-js/issues/319