### PR TITLE
closes #323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Version 8.2.5
+
+## New Features
+
+_New shiny stuff._
+
+-   Throwing a BPMN Error, either from the `ZBClient` or in the job handler of a `ZBWorker`, accepted an error message and an error code. The gRPC API for ThrowError now accepts a `variables` field, but the Node client did not allow you to set variables along with the error code and message. The Node client now accepts an object for `job.error` that includes a `variables` field, as does `ZBClient.throwError`, allowing you to set variables when throwing a BPMN error. See [#323](https://github.com/camunda-community-hub/zeebe-client-node-js/issues/323), the README file, and the [Client API documentation](https://camunda-community-hub.github.io/zeebe-client-node-js/) for more details.
+
+## Chores
+
+_Things that shouldn't have a visible impact._
+
+-   Unit tests used a unique process model for each test run. As a result, the number of deployed process models in a cluster increased over time until a SaaS cluster would fail due to sharding of the ElasticSearch. Unit tests have been refactored to reuse process models. This will have no impact for end-users, but for developers it means that you can use the same cluster for unit tests.
+
+
+
 # Version 8.2.4
 
 ## Fixes

--- a/README.md
+++ b/README.md
@@ -737,6 +737,21 @@ job.fail({
 
 Call `job.error()` to trigger a BPMN error throw event. You must pass in a string error code for the error code, and you can pass an optional error message as the second parameter. If no BPMN error catch event exists for the error code, an incident will be raised.
 
+```javascript
+job.error('RECORD_NOT_FOUND', 'Could not find the customer in the database')
+```
+
+From 8.2.5 of the client, you can update the variables in the workflow when you throw a BPMN error in a worker:
+
+```javascript
+job.error({
+    errorCode: 'RECORD_NOT_FOUND',
+    errorMessage: 'Could not find the customer in the database',
+    variables: {
+        someVariable: 'someValue'
+    }
+})
+
 Call `job.forwarded()` to release worker capacity to handle another job, without completing the job in any way with the Zeebe broker. This method supports the _decoupled job completion_ pattern. In this pattern, the worker forwards the job to another system - a lambda or a RabbitMQ queue. Some other process is ultimately responsible for completing the job.
 
 <a name = "working-with-variables"></a>

--- a/src/lib/interfaces-1.0.ts
+++ b/src/lib/interfaces-1.0.ts
@@ -143,6 +143,17 @@ declare function FailureHandler(
 	failureConfiguration: JobFailureConfiguration
 ): Promise<JOB_ACTION_ACKNOWLEDGEMENT>
 
+export interface ErrorJobWithVariables {
+	variables: JSONDoc,
+	errorCode: string,
+	errorMessage?: string
+}
+
+export type ErrorJobOutcome = (
+	errorCode: string | ErrorJobWithVariables,
+	errorMessage?: string
+) => Promise<JOB_ACTION_ACKNOWLEDGEMENT>
+
 export interface JobCompletionInterface<WorkerOutputVariables> {
 	/**
 	 * Cancel the workflow.
@@ -174,11 +185,9 @@ export interface JobCompletionInterface<WorkerOutputVariables> {
 	 * The error is handled in the process by an error catch event.
 	 * If there is no error catch event with the specified errorCode then an incident will be raised instead.
 	 */
-	error: (
-		errorCode: string,
-		errorMessage?: string
-	) => Promise<JOB_ACTION_ACKNOWLEDGEMENT>
+	error: ErrorJobOutcome
 }
+
 
 export interface ZeebeJob<
 	WorkerInputVariables = IInputVariables,

--- a/src/lib/interfaces-grpc-1.0.ts
+++ b/src/lib/interfaces-grpc-1.0.ts
@@ -341,7 +341,15 @@ export interface ThrowErrorRequest {
 	// the error code that will be matched with an error catch event
 	errorCode: string
 	// an optional error message that provides additional context
-	errorMessage: string
+	errorMessage?: string
+	/**
+	 * JSON document that will instantiate the variables at the local scope of the error catch
+	 * event that catches the thrown error; it must be a JSON object, as variables will be mapped in a
+	 * key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+	 * "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+	 * valid argument, as the root of the JSON document is an array and not an object.
+	 */
+	variables?: JSONDoc
 }
 
 export interface CompleteJobRequest<Variables = IProcessVariables> {

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -1229,8 +1229,9 @@ export class ZBClient extends TypedEmitter<typeof ConnectionStatusEvent> {
 	 * ```
 	 */
 	public throwError(throwErrorRequest: Grpc.ThrowErrorRequest) {
+		const req = stringifyVariables({...throwErrorRequest, variables: throwErrorRequest.variables ?? {}})
 		return this.executeOperation('throwError', () =>
-			this.grpc.throwErrorSync(throwErrorRequest)
+			this.grpc.throwErrorSync(req)
 		)
 	}
 


### PR DESCRIPTION
Fixes #323

## Proposed Changes

  - Add new interface to `job.error` to allow variables to be set when throwing a BPMN error 
  - Add new field to `ZBClient.throwError` for the same purpose
