### PR TITLE
fix(docs): Close an open code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ job.error({
         someVariable: 'someValue'
     }
 })
+```
 
 Call `job.forwarded()` to release worker capacity to handle another job, without completing the job in any way with the Zeebe broker. This method supports the _decoupled job completion_ pattern. In this pattern, the worker forwards the job to another system - a lambda or a RabbitMQ queue. Some other process is ultimately responsible for completing the job.
 


### PR DESCRIPTION
Fixes an issue in the README, where a code block was unclosed, and the actual markdown was rendering as code.

Before this change:

<img width="897" alt="image" src="https://github.com/camunda-community-hub/zeebe-client-node-js/assets/1627089/cd4d09e0-8533-4f7c-9425-afcf5c85e755">

After this change:

<img width="914" alt="image" src="https://github.com/camunda-community-hub/zeebe-client-node-js/assets/1627089/52050db2-5673-4479-a617-4d7a50255f24">

## Proposed Changes

  - Close an open code block in the README.md
